### PR TITLE
PostJob runners

### DIFF
--- a/vars/ghSetStatus.groovy
+++ b/vars/ghSetStatus.groovy
@@ -1,5 +1,7 @@
 // vars/ghSetStatus.groovy
 
+// Can be one of error, failure, pending, or success.
+
 def call(String message, String state, String context="ci") {
 
 	String origin

--- a/vars/postJob.groovy
+++ b/vars/postJob.groovy
@@ -35,17 +35,17 @@ def call(Closure body, Closure onSuccess=postJobDefaultFunction, Closure onFailu
       
     if (currentBuild.result == 'ABORTED') {
       echo '[postJob] Running script: ABORTED'
-	  onAborted.call()
+	  onAborted()
     }
         
     if (currentBuild.result == 'SUCCESS') {
       echo '[postJob] Running script: SUCCESS'
-	  onSuccess.call()
+	  onSuccess()
     }
         
     if (currentBuild.result == 'FAILURE') {
       echo '[postJob] Running script: FAILURE'
-	  onFailure.call()
+	  onFailure()
     }
   }
 }

--- a/vars/postJob.groovy
+++ b/vars/postJob.groovy
@@ -11,7 +11,7 @@ import java.lang.Exception
 
 // Not Built // Unstable is not supported.
 
-def call(Closure body, Closure onSuccess=postJobDefaultFunction, Closure onFailure=postJobDefaultFunction, Closure onAborted=postJobDefaultFunction) {
+def call(Closure body, Closure onSuccess=this.&postJobDefaultFunction, Closure onFailure=this.&postJobDefaultFunction, Closure onAborted=this.&postJobDefaultFunction) {
   try {
     body()
   }

--- a/vars/postJob.groovy
+++ b/vars/postJob.groovy
@@ -11,9 +11,7 @@ import java.lang.Exception
 
 // Not Built // Unstable is not supported.
 
-Closure default = this.&postJobDefaultFunction
-
-def call(Closure body, Closure onSuccess=default, Closure onFailure=default, Closure onAborted=default) {
+def call(Closure body, Closure onSuccess=postJobDefaultFunction, Closure onFailure=postJobDefaultFunction, Closure onAborted=postJobDefaultFunction) {
   try {
     body()
   }

--- a/vars/postJob.groovy
+++ b/vars/postJob.groovy
@@ -11,7 +11,7 @@ import java.lang.Exception
 
 // Not Built // Unstable is not supported.
 
-def call(Closure body, Closure onSuccess=this.&postJobDefaultFunction, Closure onFailure=this.&postJobDefaultFunction, Closure onAborted=this.&postJobDefaultFunction) {
+def call(Closure body, Closure onSuccess=postJobDefaultFunction.&call, Closure onFailure=postJobDefaultFunction.&call, Closure onAborted=postJobDefaultFunction.&call) {
   try {
     body()
   }

--- a/vars/postJob.groovy
+++ b/vars/postJob.groovy
@@ -11,12 +11,7 @@ import java.lang.Exception
 
 // Not Built // Unstable is not supported.
 
-// Default function to call when the caller does not specify the called on[..] Closure.
-def default() {
-  echo '[postJob] No script specified.'
-}
-
-def call(Closure body, Closure onSuccess=default, Closure onFailure=default, Closure onAborted=default) {
+def call(Closure body, Closure onSuccess=postJobDefaultFunction, Closure onFailure=postJobDefaultFunction, Closure onAborted=postJobDefaultFunction) {
   try {
     body()
   }

--- a/vars/postJob.groovy
+++ b/vars/postJob.groovy
@@ -34,7 +34,7 @@ def call(Closure body, Closure onSuccess=postJobDefaultFunction, Closure onFailu
 	echo "[postJob] finally block triggered, currentBuild.result: ${currentBuild.result}"
       
     if (currentBuild.result == 'ABORTED') {
-      echo '[postJob] Running script: 'ABORTED'
+      echo '[postJob] Running script: ABORTED'
 	  onAborted()
     }
         

--- a/vars/postJob.groovy
+++ b/vars/postJob.groovy
@@ -35,17 +35,17 @@ def call(Closure body, Closure onSuccess=postJobDefaultFunction, Closure onFailu
       
     if (currentBuild.result == 'ABORTED') {
       echo '[postJob] Running script: ABORTED'
-	  onAborted()
+	  onAborted.call()
     }
         
     if (currentBuild.result == 'SUCCESS') {
       echo '[postJob] Running script: SUCCESS'
-	  onSuccess()
+	  onSuccess.call()
     }
         
     if (currentBuild.result == 'FAILURE') {
       echo '[postJob] Running script: FAILURE'
-	  onFailure()
+	  onFailure.call()
     }
   }
 }

--- a/vars/postJob.groovy
+++ b/vars/postJob.groovy
@@ -11,7 +11,9 @@ import java.lang.Exception
 
 // Not Built // Unstable is not supported.
 
-def call(Closure body, Closure onSuccess=postJobDefaultFunction, Closure onFailure=postJobDefaultFunction, Closure onAborted=postJobDefaultFunction) {
+Closure default = this.&postJobDefaultFunction
+
+def call(Closure body, Closure onSuccess=default, Closure onFailure=default, Closure onAborted=default) {
   try {
     body()
   }

--- a/vars/postJob.groovy
+++ b/vars/postJob.groovy
@@ -1,0 +1,56 @@
+// vars/postJob.groovy
+
+import org.jenkinsci.plugins.workflow.steps.FlowInterruptedException
+import java.lang.Exception
+
+// Currently supported outcomes.
+
+// - ABORTED
+// - SUCCESS
+// - FAILURE
+
+// Not Built // Unstable is not supported.
+
+// Default function to call when the caller does not specify the called on[..] Closure.
+def default() {
+  echo '[postJob] No script specified.'
+}
+
+def call(Closure body, Closure onSuccess=default, Closure onFailure=default, Closure onAborted=default) {
+  try {
+    body()
+  }
+  catch (Exception err) {
+    if (err instanceof FlowInterruptedException) {
+      // Job aborted.
+        echo '[postJob] setting currentResult to interrupted. (aborted)'
+        currentBuild.result = 'ABORTED'
+    } else {
+      // General job failure.
+      echo '[postJob] setting currentResult to FAILURE.'
+      currentBuild.result = 'FAILURE'
+    }
+  } finally {
+    if (currentBuild.result == null) {
+      echo "[postJob] currentBuild.result not set, setting to currentBuild.currentResult (${currentBuild.currentResult})"
+      currentBuild.result = currentBuild.currentResult
+    }
+      
+	echo "[postJob] finally block triggered, currentBuild.result: ${currentBuild.result}"
+      
+    if (currentBuild.result == 'ABORTED') {
+      echo '[postJob] Running script: 'ABORTED'
+	  onAborted()
+    }
+        
+    if (currentBuild.result == 'SUCCESS') {
+      echo '[postJob] Running script: SUCCESS'
+	  onSuccess()
+    }
+        
+    if (currentBuild.result == 'FAILURE') {
+      echo '[postJob] Running script: FAILURE'
+	  onFailure()
+    }
+  }
+}

--- a/vars/postJobDefaultFunction.groovy
+++ b/vars/postJobDefaultFunction.groovy
@@ -1,0 +1,6 @@
+// vars/postJobDefaultFunction.groovy
+
+// Default function to call when the caller does not specify the called on[..] Closure.
+def call() {
+  echo '[postJob] No script specified.'
+}

--- a/vars/postJobGhStatus.groovy
+++ b/vars/postJobGhStatus.groovy
@@ -1,0 +1,17 @@
+// vars/postJobGhStatus.groovy
+
+def onSuccess() {
+  ghSetStatus("The job completed successfully.", "success", "ci")
+}
+
+def onFailure() {
+  ghSetStatus("The job failed.", "failure", "ci")
+}
+
+def onAborted() {
+  ghSetStatus("The job was aborted.", "error", "ci")
+}
+
+def call(Closure body) {
+  postJob(body, onSuccess, onFailure, onAborted)
+}

--- a/vars/postJobGhStatus.groovy
+++ b/vars/postJobGhStatus.groovy
@@ -13,5 +13,5 @@ def onAborted() {
 }
 
 def call(Closure body) {
-  postJob(body, onSuccess, onFailure, onAborted)
+  postJob(body, this.&onSuccess, this.&onFailure, this.&onAborted)
 }


### PR DESCRIPTION
Added vars:

- `postJob`
- `postJobGhStatus`
- `postJobDefaultFunction`

postJob supports aborted, success, failure modes.

Basically a built-in version of this: https://github.com/Prouser123/shields-endpoints/blob/79021cd5f6bcbc5800a84931b1ab6e461dc2d312/Jenkinsfile